### PR TITLE
Move python install to libtorch/Dockerfile

### DIFF
--- a/common/install_rocm_magma.sh
+++ b/common/install_rocm_magma.sh
@@ -9,8 +9,6 @@ set -ex
 # TODO (2)
 MKLROOT=${MKLROOT:-/opt/intel}
 
-apt-get install -y python
-
 # "install" hipMAGMA into /opt/rocm/magma by copying after build
 git clone https://bitbucket.org/icl/magma.git
 pushd magma

--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -71,9 +71,10 @@ ENV MKLROOT /opt/intel
 ADD ./common/install_rocm.sh install_rocm.sh
 ADD ./common/install_rocm_drm.sh install_rocm_drm.sh
 ADD ./common/install_rocm_magma.sh install_rocm_magma.sh
-# gfortran needed for building magma from source for ROCm
+# gfortran and python needed for building magma from source for ROCm
 RUN apt-get update -y && \
     apt-get install gfortran -y && \
+    apt-get install python -y && \
     apt-get clean
 
 FROM rocm as rocm5.2


### PR DESCRIPTION
build_manylinux_image.sh failing with error:
```
#63 [rocm_final  7/10] RUN bash ./install_rocm_magma.sh && rm install_rocm_magma.sh
#63 sha256:f92e89921615840c390212d4d9246862670d672114ffe61a2eeee7d45c3deda6
#63 0.598 + MKLROOT=/opt/intel
#63 0.598 + apt-get install -y python
#63 0.600 ./install_rocm_magma.sh: line 12: apt-get: command not found
#63 ERROR: executor failed running [/bin/sh -c bash ./install_rocm_magma.sh && rm install_rocm_magma.sh]: exit code: 127
------
 > [rocm_final  7/10] RUN bash ./install_rocm_magma.sh && rm install_rocm_magma.sh:
------
executor failed running [/bin/sh -c bash ./install_rocm_magma.sh && rm install_rocm_magma.sh]: exit code: 127
```

python installation is needed when building magma from source for ROCm (not needed for CUDA because CUDA wheel build flow installs prebuilt magma): https://bitbucket.org/icl/magma/src/c62d700d880c7283b33fb1d615d62fc9c7f7ca21/tools/codegen.py

- CentOS-based base docker image for wheels already has python installation when building magma for ROCm:
https://github.com/ROCmSoftwarePlatform/builder/blob/fe0f98798c13a03722dc2b6a22bb8dc313d24083/manywheel/Dockerfile#L85
and
https://github.com/ROCmSoftwarePlatform/builder/blob/fe0f98798c13a03722dc2b6a22bb8dc313d24083/manywheel/Dockerfile#L158
- Ubuntu-based base docker image for libtorch doesn't have python installation when building magma for ROCm:
https://github.com/ROCmSoftwarePlatform/builder/blob/fe0f98798c13a03722dc2b6a22bb8dc313d24083/libtorch/Dockerfile#L32
https://github.com/ROCmSoftwarePlatform/builder/blob/fe0f98798c13a03722dc2b6a22bb8dc313d24083/libtorch/Dockerfile#L67
https://github.com/ROCmSoftwarePlatform/builder/blob/fe0f98798c13a03722dc2b6a22bb8dc313d24083/libtorch/Dockerfile#L110