### PR TITLE
Disable MLIR backend when building MIOpen

### DIFF
--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -60,7 +60,7 @@ MIOPEN_CMAKE_COMMON_FLAGS="
 "
 # Pull MIOpen repo and set DMIOPEN_EMBED_DB based on ROCm version
 if [[ $ROCM_INT -ge 50200 ]]; then
-    MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx906_60;gfx90878;gfx90a6e;gfx1030_36"
+    MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx906_60;gfx90878;gfx90a6e;gfx1030_36 -DMIOPEN_USE_MLIR=Off"
     MIOPEN_BRANCH="release/rocm-rel-5.2-staging"
 elif [[ $ROCM_INT -ge 50100 ]]; then
     MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx906_60;gfx90878;gfx90a6e;gfx1030_36"


### PR DESCRIPTION
Background: https://ontrack-internal.amd.com/browse/SWDEV-356492

Verified that PyTorch wheels generated using this fix do not throw any errors when running pytorch-micro-benchmarking on gfx908.

Wheels with MLIR disabled generated in CI job: http://rocmhead.amd.com:8080/job/pytorch/job/manylinux_rocm_wheels/144/