### PR TITLE
Use staging branch of MIOpen for ROCm5.3

### DIFF
--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -61,7 +61,7 @@ MIOPEN_CMAKE_COMMON_FLAGS="
 # Pull MIOpen repo and set DMIOPEN_EMBED_DB based on ROCm version
 if [[ $ROCM_INT -eq 50300 ]]; then
     MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx906_60;gfx90878;gfx90a6e;gfx1030_36 -DMIOPEN_USE_MLIR=Off"
-    MIOPEN_BRANCH="release/rocm-rel-5.3"
+    MIOPEN_BRANCH="release/rocm-rel-5.3-staging"
 elif [[ $ROCM_INT -eq 50200 ]]; then
     MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx906_60;gfx90878;gfx90a6e;gfx1030_36 -DMIOPEN_USE_MLIR=Off"
     MIOPEN_BRANCH="release/rocm-rel-5.2-staging"


### PR DESCRIPTION
Certain tuning updates were put into the staging branch: https://github.com/ROCmSoftwarePlatform/MIOpen/compare/release/rocm-rel-5.3...release/rocm-rel-5.3-staging

![image](https://user-images.githubusercontent.com/37884920/194000863-c476ea47-952f-4f53-abc3-6cd906c4162e.png)
