### PR TITLE
Disable MIOpen build from source for PyTorch wheels

### DIFF
--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -166,10 +166,3 @@ ADD ./common/install_rocm_drm.sh install_rocm_drm.sh
 RUN bash ./install_rocm_drm.sh && rm install_rocm_drm.sh
 ADD ./common/install_rocm_magma.sh install_rocm_magma.sh
 RUN bash ./install_rocm_magma.sh && rm install_rocm_magma.sh
-# cmake is already installed inside the rocm base image, but both 2 and 3 exist
-# cmake3 is needed for the later MIOpen custom build, so that step is last.
-RUN yum install -y cmake3 && \
-    rm -f /usr/bin/cmake && \
-    ln -s /usr/bin/cmake3 /usr/bin/cmake
-ADD ./common/install_miopen.sh install_miopen.sh
-RUN bash ./install_miopen.sh ${ROCM_VERSION} && rm install_miopen.sh

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -143,7 +143,7 @@ OTHER_FILES=$(ls $ROCBLAS_LIB_SRC | grep -v gfx)
 ROCBLAS_LIB_FILES=($ARCH_SPECIFIC_FILES $OTHER_FILES)
 
 # MIOpen library files
-MIOPEN_SHARE_SRC=$ROCM_HOME/miopen/share/miopen/db
+MIOPEN_SHARE_SRC=$ROCM_HOME/share/miopen/db
 MIOPEN_SHARE_DST=share/miopen/db
 MIOPEN_SHARE_FILES=($(ls $MIOPEN_SHARE_SRC | grep -E $ARCH))
 

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -142,6 +142,11 @@ ARCH_SPECIFIC_FILES=$(ls $ROCBLAS_LIB_SRC | grep -E $ARCH)
 OTHER_FILES=$(ls $ROCBLAS_LIB_SRC | grep -v gfx)
 ROCBLAS_LIB_FILES=($ARCH_SPECIFIC_FILES $OTHER_FILES)
 
+# MIOpen library files
+MIOPEN_SHARE_SRC=$ROCM_HOME/miopen/share/miopen/db
+MIOPEN_SHARE_DST=share/miopen/db
+MIOPEN_SHARE_FILES=($(ls $MIOPEN_SHARE_SRC | grep -E $ARCH))
+
 # ROCm library files
 ROCM_SO_PATHS=()
 for lib in "${ROCM_SO_FILES[@]}"
@@ -170,11 +175,13 @@ DEPS_SONAME=(
 
 DEPS_AUX_SRCLIST=(
     "${ROCBLAS_LIB_FILES[@]/#/$ROCBLAS_LIB_SRC/}"
+    "${MIOPEN_SHARE_FILES[@]/#/$MIOPEN_SHARE_SRC/}"
     "/opt/amdgpu/share/libdrm/amdgpu.ids"
 )
 
 DEPS_AUX_DSTLIST=(
     "${ROCBLAS_LIB_FILES[@]/#/$ROCBLAS_LIB_DST/}"
+    "${MIOPEN_SHARE_FILES[@]/#/$MIOPEN_SHARE_DST/}"
     "share/libdrm/amdgpu.ids"
 )
 


### PR DESCRIPTION
Avoid rebuilding MIOpen from source for PyTorch wheels, and instead use the MIOpen .so that comes with the ROCm release. Bundle the .db files in the wheel instead of embedding them into the MIOpen .so. 

BONUS: This should enable file I/O for the MIOpen .so, which can then read .kdb files if they're placed in the correct path (ie. ../share (wrt the location of the libMIOpen.so) by the user. Just to clarify, we will NOT bundle the .kdb files with the wheels due to their large size, so the user will need to manually install them and place them in the correct path above (we could provide the user a helper script for the same purpose).

FUTURE TODO:
1. Helper script to install the .kdb files in the correct location for the wheels.
2. Builder script to install miopen binaries from a non-standard location if needed.

Fixes: https://ontrack-internal.amd.com/browse/ROCMOPS-3381