### PR TITLE
Fix conda install on distributions with strict POSIX sh

### DIFF
--- a/common/install_conda.sh
+++ b/common/install_conda.sh
@@ -5,7 +5,7 @@ set -ex
 # Anaconda
 wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 chmod +x  Miniconda3-latest-Linux-x86_64.sh
-./Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda
+bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda
 rm Miniconda3-latest-Linux-x86_64.sh
 export PATH=/opt/conda/bin:$PATH
 conda install -y conda-build anaconda-client git ninja


### PR DESCRIPTION
We require the same fix that was made on upstream pytorch https://github.com/pytorch/pytorch/pull/91371
https://github.com/ROCmSoftwarePlatform/pytorch/commit/b72ec7cfbfa7e985986c4ac7e35bd486ffe5e212

Without this change install_conda.sh stage fails
```
#21 6.254 CondaFileIOError: '/opt/conda/pkgs/envs/*/env.txt'. [Errno 2] No such file or directory: '/opt/conda/pkgs/envs/*/env.txt'
#21 6.254 
#21 ERROR: executor failed running [/bin/sh -c bash ./install_conda.sh && rm install_conda.sh]: exit code: 1
------
 > [conda 2/3] RUN bash ./install_conda.sh && rm install_conda.sh:
------
executor failed running [/bin/sh -c bash ./install_conda.sh && rm install_conda.sh]: exit code: 1
```

Locally tested with the `/builder/libtorch/build_docker.sh`