### PR TITLE
Fix how libtorch picks the python version

### DIFF
--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -65,13 +65,11 @@ fi
 # ever pass one python version, so we assume that DESIRED_PYTHON is not a list
 # in this case
 if [[ -n "$DESIRED_PYTHON" && "$DESIRED_PYTHON" != cp* ]]; then
-    if [[ "$DESIRED_PYTHON" == '2.7mu' ]]; then
-      DESIRED_PYTHON='cp27-cp27mu'
-    elif [[ "$DESIRED_PYTHON" == '3.8m' ]]; then
-      DESIRED_PYTHON='cp38-cp38'
+    if [[ "$DESIRED_PYTHON" == '3.7' ]]; then
+      DESIRED_PYTHON='cp37-cp37m'
     else
       python_nodot="$(echo $DESIRED_PYTHON | tr -d m.u)"
-      DESIRED_PYTHON="cp${python_nodot}-cp${python_nodot}m"
+      DESIRED_PYTHON="cp${python_nodot}-cp${python_nodot}"
     fi
 fi
 pydir="/opt/python/$DESIRED_PYTHON"


### PR DESCRIPTION
(cherry picked from commit 29502fbb4173621aaca483fa6895313b30d2263d)

This upstream commit fixes the observed in https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3522 where supplying multiple PYTHON_VERSIONS to the CI would cause DESIRED_CUDA to be set incorrectly to the python version resulting in ROCM_VERSION being incorrectly set causing issues in build_rocm.sh

Failing CI:
http://rocmhead.amd.com:8080/job/pytorch/job/manylinux_rocm_wheels_freestyle/210/

Passing CI (After this fix)
http://rocmhead.amd.com:8080/job/pytorch/job/manylinux_rocm_wheels_freestyle/230/