### PR TITLE
Update cmake version 3.18.4

### DIFF
--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -168,8 +168,9 @@ ADD ./common/install_rocm_magma.sh install_rocm_magma.sh
 RUN bash ./install_rocm_magma.sh && rm install_rocm_magma.sh
 # cmake is already installed inside the rocm base image, but both 2 and 3 exist
 # cmake3 is needed for the later MIOpen custom build, so that step is last.
-RUN yum install -y cmake3 && \
-    rm -f /usr/bin/cmake && \
-    ln -s /usr/bin/cmake3 /usr/bin/cmake
+RUN rpm -e cmake && \
+    pip3 install cmake==3.18.4 && \
+    ln -sf /usr/local/bin/cmake /usr/bin/cmake && \
+    ln -sf /usr/local/bin/cmake /usr/bin/cmake3
 ADD ./common/install_miopen.sh install_miopen.sh
 RUN bash ./install_miopen.sh ${ROCM_VERSION} && rm install_miopen.sh


### PR DESCRIPTION
Upstream is on 3.18.4

Build break seen when building pytorch 1.13 wheels - http://rocm-ci.amd.com/view/Release-5.4/job/pytorch_manylinux_libtorch_wheels_rel-5.4/27/console