### PR TITLE
Cherry-pick patch for patchelf from upstream

### DIFF
--- a/common/install_patchelf.sh
+++ b/common/install_patchelf.sh
@@ -2,7 +2,9 @@
 
 set -ex
 
-git clone https://github.com/NixOS/patchelf
+# Pin the version to latest release 0.17.2, building newer commit starts
+# to fail on the current image
+git clone -b 0.17.2 --single-branch https://github.com/NixOS/patchelf
 cd patchelf
 sed -i 's/serial/parallel/g' configure.ac
 ./bootstrap.sh


### PR DESCRIPTION
https://github.com/pytorch/builder/commit/18c5017d9eedd2e5e203608e9ad6c05a2324b3ac since tip-of-tree patchelf repo was exhibiting the following error for various libraries in wheel build jobs:
"ELF load command address/offset not properly aligned"