### PR TITLE
[SWDEV-404135] Add msccl-algorithms directory to PyTorch wheel

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -155,7 +155,7 @@ MIOPEN_SHARE_DST=share/miopen/db
 MIOPEN_SHARE_FILES=($(ls $MIOPEN_SHARE_SRC | grep -E $ARCH))
 
 # RCCL library files
-RCCL_SHARE_SRC=$ROCM_HOME/rccl/lib/msccl-algorithms
+RCCL_SHARE_SRC=$ROCM_HOME/lib/msccl-algorithms
 RCCL_SHARE_DST=lib/msccl-algorithms
 RCCL_SHARE_FILES=($(ls $RCCL_SHARE_SRC))
 

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -154,6 +154,11 @@ MIOPEN_SHARE_SRC=$ROCM_HOME/share/miopen/db
 MIOPEN_SHARE_DST=share/miopen/db
 MIOPEN_SHARE_FILES=($(ls $MIOPEN_SHARE_SRC | grep -E $ARCH))
 
+# RCCL library files
+RCCL_SHARE_SRC=$ROCM_HOME/rccl/lib/msccl-algorithms
+RCCL_SHARE_DST=lib/msccl-algorithms
+RCCL_SHARE_FILES=($(ls $RCCL_SHARE_SRC))
+
 # ROCm library files
 ROCM_SO_PATHS=()
 for lib in "${ROCM_SO_FILES[@]}"
@@ -187,12 +192,14 @@ DEPS_SONAME=(
 DEPS_AUX_SRCLIST=(
     "${ROCBLAS_LIB_FILES[@]/#/$ROCBLAS_LIB_SRC/}"
     "${MIOPEN_SHARE_FILES[@]/#/$MIOPEN_SHARE_SRC/}"
+    "${RCCL_SHARE_FILES[@]/#/$RCCL_SHARE_SRC/}"
     "/opt/amdgpu/share/libdrm/amdgpu.ids"
 )
 
 DEPS_AUX_DSTLIST=(
     "${ROCBLAS_LIB_FILES[@]/#/$ROCBLAS_LIB_DST/}"
     "${MIOPEN_SHARE_FILES[@]/#/$MIOPEN_SHARE_DST/}"
+    "${RCCL_SHARE_FILES[@]/#/$RCCL_SHARE_DST/}"
     "share/libdrm/amdgpu.ids"
 )
 


### PR DESCRIPTION
Verified successfully via: http://rocmhead.amd.com:8080/job/pytorch/job/dev/job/manylinux_rocm_wheels/228/

Relevant snippet
```
[2023-06-12T16:02:56.679Z] ++ srcpath=/opt/rocm/lib/msccl-algorithms/allreduce-allpairs-16n-16tb.xml
[2023-06-12T16:02:56.679Z] ++ dstpath=torch/lib/msccl-algorithms/allreduce-allpairs-16n-16tb.xml
[2023-06-12T16:02:56.679Z] +++ dirname torch/lib/msccl-algorithms/allreduce-allpairs-16n-16tb.xml
[2023-06-12T16:02:56.679Z] ++ mkdir -p torch/lib/msccl-algorithms
[2023-06-12T16:02:56.679Z] ++ cp /opt/rocm/lib/msccl-algorithms/allreduce-allpairs-16n-16tb.xml torch/lib/msccl-algorithms/allreduce-allpairs-16n-16tb.xml
```