### PR TITLE
Fix msccl-algorithms logic for ROCm5.6 and ROCm5.7

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -202,10 +202,17 @@ if [[ $ROCM_INT -ge 50500 ]]; then
 
     DEPS_AUX_SRCLIST+=(${MIOPEN_SHARE_FILES[@]/#/$MIOPEN_SHARE_SRC/})
     DEPS_AUX_DSTLIST+=(${MIOPEN_SHARE_FILES[@]/#/$MIOPEN_SHARE_DST/})
-elif [[ $ROCM_INT -ge 50600 ]]; then
+fi
+
+if [[ $ROCM_INT -ge 50600 ]]; then
     # RCCL library files
-    RCCL_SHARE_SRC=$ROCM_HOME/lib/msccl-algorithms
-    RCCL_SHARE_DST=lib/msccl-algorithms
+    if [[ $ROCM_INT -ge 50700 ]]; then
+        RCCL_SHARE_SRC=$ROCM_HOME/share/rccl/msccl-algorithms
+        RCCL_SHARE_DST=share/rccl/msccl-algorithms
+    else
+        RCCL_SHARE_SRC=$ROCM_HOME/lib/msccl-algorithms
+        RCCL_SHARE_DST=lib/msccl-algorithms
+    fi
     RCCL_SHARE_FILES=($(ls $RCCL_SHARE_SRC))
 
     DEPS_AUX_SRCLIST+=(${RCCL_SHARE_FILES[@]/#/$RCCL_SHARE_SRC/})


### PR DESCRIPTION
Fix erroneous logic that was skipping msccl files even for ROCm5.6; update msccl path for ROCm5.7

Tested via http://rocmhead.amd.com:8080/job/pytorch/job/dev/job/manylinux_rocm_wheels/242/

```
[2023-08-04T08:36:36.228Z] ++ srcpath=/opt/rocm/lib/msccl-algorithms/allreduce-allpairs-16n-16tb.xml
[2023-08-04T08:36:36.228Z] ++ dstpath=torch/lib/msccl-algorithms/allreduce-allpairs-16n-16tb.xml
[2023-08-04T08:36:36.228Z] +++ dirname torch/lib/msccl-algorithms/allreduce-allpairs-16n-16tb.xml
[2023-08-04T08:36:36.228Z] ++ mkdir -p torch/lib/msccl-algorithms
[2023-08-04T08:36:36.228Z] ++ cp /opt/rocm/lib/msccl-algorithms/allreduce-allpairs-16n-16tb.xml torch/lib/msccl-algorithms/allreduce-allpairs-16n-16tb.xml
[2023-08-04T08:36:36.228Z] ++ (( ++i ))
[2023-08-04T08:36:36.228Z] ++ (( i<1086 ))
[2023-08-04T08:36:36.228Z] ++ srcpath=/opt/rocm/lib/msccl-algorithms/allreduce-allpairs-16n-32tb.xml
[2023-08-04T08:36:36.228Z] ++ dstpath=torch/lib/msccl-algorithms/allreduce-allpairs-16n-32tb.xml
[2023-08-04T08:36:36.228Z] +++ dirname torch/lib/msccl-algorithms/allreduce-allpairs-16n-32tb.xml
[2023-08-04T08:36:36.228Z] ++ mkdir -p torch/lib/msccl-algorithms
[2023-08-04T08:36:36.489Z] ++ cp /opt/rocm/lib/msccl-algorithms/allreduce-allpairs-16n-32tb.xml torch/lib/msccl-algorithms/allreduce-allpairs-16n-32tb.xml
```