### PR TITLE
Adding back setting of ROCM_PATH env

### DIFF
--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -161,6 +161,9 @@ ARG PYTORCH_BRANCH
 ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
 ENV ROCM_VERSION ${ROCM_VERSION}
 
+# Adding ROCM_PATH env var so that cmake find HIP works
+ENV ROCM_PATH /opt/rocm
+
 # No need to install ROCm as base docker image should have full ROCm install
 #ADD ./common/install_rocm.sh install_rocm.sh
 #RUN ROCM_VERSION=${ROCM_VERSION} bash ./install_rocm.sh && rm install_rocm.sh


### PR DESCRIPTION
This is done as a workaround for - https://ontrack-internal.amd.com/browse/SWDEV-429841